### PR TITLE
feat(Lecture): 특강 선택 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,14 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@golevelup/ts-jest": "^0.5.6",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.2.3",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.2",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "sqlite3": "^5.1.7",
@@ -970,6 +973,12 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@golevelup/ts-jest": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.5.6.tgz",
+      "integrity": "sha512-QnxP42Qu9M2UogdrF2kxpZcgWeW9R3WoUr+LdpcsbkvX3LjEoDYgrJ/PnV/QUCbxB1gaKbhR0ZxlDxE1cPkpDg==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -2421,6 +2430,12 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.12.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.2.tgz",
+      "integrity": "sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==",
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -3794,6 +3809,23 @@
       "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -7220,6 +7252,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.9.tgz",
+      "integrity": "sha512-Zs5wf5HaWzW2/inlupe2tstl0I/Tbqo7lH20ZLr6Is58u7Dz2n+gRFGNlj9/gWxFvNfp9+YyDsiegjNhdixB9A==",
+      "license": "MIT"
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -10677,6 +10715,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,14 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@golevelup/ts-jest": "^0.5.6",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.2",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,17 +2,22 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Lecture } from './lecture/entity/lecture.entity';
+import { LectureModule } from './lecture/lecture.module';
+import { LectureSchedule } from './lecture/entity/lecture.schedule.entity';
+import { LectureStatus } from './lecture/entity/lecture.status.entity';
 
 @Module({
   imports: [
+    LectureModule,
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'LectureReservation',
       autoLoadEntities: true,
       synchronize: true,
       logging: true,
-      dropSchema: true,
-      entities: [],
+      // dropSchema: true,
+      entities: [Lecture, LectureStatus, LectureSchedule],
     }),
   ],
   controllers: [AppController],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,10 @@
-import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AppController } from './app.controller';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Lecture } from './lecture/entity/lecture.entity';
 import { LectureModule } from './lecture/lecture.module';
-import { LectureSchedule } from './lecture/entity/lecture.schedule.entity';
+import { Lecture } from './lecture/entity/lecture.entity';
+import { LectureOption } from './lecture/entity/lecture.option.entity';
 import { LectureStatus } from './lecture/entity/lecture.status.entity';
 
 @Module({
@@ -17,7 +17,7 @@ import { LectureStatus } from './lecture/entity/lecture.status.entity';
       synchronize: true,
       logging: true,
       // dropSchema: true,
-      entities: [Lecture, LectureStatus, LectureSchedule],
+      entities: [Lecture, LectureStatus, LectureOption],
     }),
   ],
   controllers: [AppController],

--- a/src/common/pipe/parse.date.pipe.ts
+++ b/src/common/pipe/parse.date.pipe.ts
@@ -1,0 +1,79 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+
+@Injectable()
+export class ParseDatePipe implements PipeTransform<string, Date> {
+  transform(value: string): Date {
+    this.validateDateFormat(value);
+    this.validateDateValue(value);
+
+    return this.parseToDate(value);
+  }
+
+  // YYYY-MM-DD 형식의 문자열을 Date 객체로 변환
+  private parseToDate(value: string): Date {
+    const [year, month, day] = value.split('-').map(Number);
+    return new Date(year, month - 1, day);
+  }
+
+  // 날짜 형식 검증 (YYYY-MM-DD)
+  private validateDateFormat(dateString: string): void {
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+    if (!dateRegex.test(dateString)) {
+      throw new BadRequestException(
+        'Invalid date format. Expected YYYY-MM-DD.',
+      );
+    }
+  }
+
+  // 날짜 값 검증 (월, 일 범위)
+  private validateDateValue(dateString: string): void {
+    const [year, month, day] = dateString.split('-').map(Number);
+
+    this.validateMonthRange(month);
+    this.validateDayRange(year, month, day);
+  }
+
+  // 월 범위 검증
+  private validateMonthRange(month: number): void {
+    if (month < 1 || month > 12) {
+      throw new BadRequestException(
+        'Invalid month. Expected value between 1 and 12.',
+      );
+    }
+  }
+
+  // 일 범위 검증
+  private validateDayRange(year: number, month: number, day: number): void {
+    const daysInMonth = this.getDaysInMonth(year, month);
+    if (day < 1 || day > daysInMonth) {
+      throw new BadRequestException(
+        `Invalid day for the month. Expected value between 1 and ${daysInMonth}.`,
+      );
+    }
+  }
+
+  // 월에 따른 일 수 반환
+  private getDaysInMonth(year: number, month: number): number {
+    const daysInMonths = [
+      31, // 1월
+      this.isLeapYear(year) ? 29 : 28, // 2월
+      31,
+      30,
+      31,
+      30,
+      31,
+      31,
+      30,
+      31,
+      30,
+      31, // 3월 ~ 12월
+    ];
+    return daysInMonths[month - 1];
+  }
+
+  // 윤년 계산
+  private isLeapYear(year: number): boolean {
+    return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  }
+}

--- a/src/lecture/dto/lecture.dto.ts
+++ b/src/lecture/dto/lecture.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsString } from 'class-validator';
+
+export class LectureDto {
+  @IsInt()
+  id: number;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  lecturer: string;
+}

--- a/src/lecture/dto/lecture.status.dto.ts
+++ b/src/lecture/dto/lecture.status.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, Min } from 'class-validator';
+
+// 특강 상태 DTO
+export class LectureStatusDto {
+  @IsInt()
+  id: number;
+
+  @IsInt()
+  @Min(0)
+  availableSeats: number;
+}

--- a/src/lecture/dto/lecutre.list.dto.ts
+++ b/src/lecture/dto/lecutre.list.dto.ts
@@ -1,5 +1,4 @@
-import { IsDateString, IsInt, Min } from 'class-validator';
-import { LectureDto } from './lecture.dto';
+import { IsDateString, IsInt, IsString, Min } from 'class-validator';
 
 // 특강 목록 DTO
 export class LectureListDto {
@@ -16,5 +15,9 @@ export class LectureListDto {
   @Min(0)
   availableSeats: number;
 
-  lecture: LectureDto;
+  @IsString()
+  title: string;
+
+  @IsString()
+  coach: string;
 }

--- a/src/lecture/dto/lecutre.list.dto.ts
+++ b/src/lecture/dto/lecutre.list.dto.ts
@@ -1,0 +1,20 @@
+import { IsDateString, IsInt, Min } from 'class-validator';
+import { LectureDto } from './lecture.dto';
+
+// 특강 목록 DTO
+export class LectureListDto {
+  @IsInt()
+  id: number;
+
+  @IsDateString()
+  lectureDate: string;
+
+  @IsInt()
+  capacity: number;
+
+  @IsInt()
+  @Min(0)
+  availableSeats: number;
+
+  lecture: LectureDto;
+}

--- a/src/lecture/entity/lecture.entity.ts
+++ b/src/lecture/entity/lecture.entity.ts
@@ -1,8 +1,7 @@
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
-import { LectureSchedule } from './lecture.schedule.entity';
-import { LectureStatus } from './lecture.status.entity';
+import { LectureOption } from './lecture.option.entity';
 
-@Entity()
+@Entity('lecture')
 export class Lecture {
   @PrimaryGeneratedColumn({ type: 'int' })
   id: number;
@@ -11,14 +10,8 @@ export class Lecture {
   title: string;
 
   @Column({ type: 'varchar', length: 255 })
-  lecturer: string;
+  coach: string;
 
-  @OneToMany(
-    () => LectureSchedule,
-    (lectureSchedule) => lectureSchedule.lecture,
-  )
-  lectureSchedule: LectureSchedule[];
-
-  @OneToMany(() => LectureStatus, (lectureStatus) => lectureStatus.lecture)
-  lectureStatus: LectureStatus[];
+  @OneToMany(() => LectureOption, (lectureOption) => lectureOption.lecture)
+  lectureOption: LectureOption[];
 }

--- a/src/lecture/entity/lecture.entity.ts
+++ b/src/lecture/entity/lecture.entity.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { LectureSchedule } from './lecture.schedule.entity';
+import { LectureStatus } from './lecture.status.entity';
+
+@Entity()
+export class Lecture {
+  @PrimaryGeneratedColumn({ type: 'int' })
+  id: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  title: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  lecturer: string;
+
+  @OneToMany(
+    () => LectureSchedule,
+    (lectureSchedule) => lectureSchedule.lecture,
+  )
+  lectureSchedule: LectureSchedule[];
+
+  @OneToMany(() => LectureStatus, (lectureStatus) => lectureStatus.lecture)
+  lectureStatus: LectureStatus[];
+}

--- a/src/lecture/entity/lecture.option.entity.ts
+++ b/src/lecture/entity/lecture.option.entity.ts
@@ -2,14 +2,14 @@ import {
   Column,
   Entity,
   ManyToOne,
-  OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Lecture } from './lecture.entity';
 import { LectureStatus } from './lecture.status.entity';
 
-@Entity()
-export class LectureSchedule {
+@Entity('lecture_option')
+export class LectureOption {
   @PrimaryGeneratedColumn({ type: 'int' })
   id: number;
 
@@ -19,12 +19,10 @@ export class LectureSchedule {
   @Column({ type: 'date' })
   lectureDate: Date;
 
-  @ManyToOne(() => Lecture, (lecture) => lecture.lectureSchedule)
+  @ManyToOne(() => Lecture, (lecture) => lecture.lectureOption)
   lecture: Lecture;
 
-  @OneToMany(
-    () => LectureStatus,
-    (lectureStatus) => lectureStatus.lectureSchedule,
-  )
-  lectureStatus: LectureStatus[];
+  // 1:1 관계 설정 (LectureOption은 하나의 LectureStatus를 가짐)
+  @OneToOne(() => LectureStatus, (lectureStatus) => lectureStatus.lectureOption)
+  lectureStatus: LectureStatus;
 }

--- a/src/lecture/entity/lecture.schedule.entity.ts
+++ b/src/lecture/entity/lecture.schedule.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Lecture } from './lecture.entity';
+import { LectureStatus } from './lecture.status.entity';
+
+@Entity()
+export class LectureSchedule {
+  @PrimaryGeneratedColumn({ type: 'int' })
+  id: number;
+
+  @Column({ type: 'int' })
+  capacity: number;
+
+  @Column({ type: 'date' })
+  lectureDate: Date;
+
+  @ManyToOne(() => Lecture, (lecture) => lecture.lectureSchedule)
+  lecture: Lecture;
+
+  @OneToMany(
+    () => LectureStatus,
+    (lectureStatus) => lectureStatus.lectureSchedule,
+  )
+  lectureStatus: LectureStatus[];
+}

--- a/src/lecture/entity/lecture.status.entity.ts
+++ b/src/lecture/entity/lecture.status.entity.ts
@@ -1,8 +1,13 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
-import { LectureSchedule } from './lecture.schedule.entity';
-import { Lecture } from './lecture.entity';
+import { LectureOption } from './lecture.option.entity';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
-@Entity()
+@Entity('lecture_status')
 export class LectureStatus {
   @PrimaryGeneratedColumn({ type: 'int' })
   id: number;
@@ -10,12 +15,7 @@ export class LectureStatus {
   @Column({ type: 'int' })
   available_seats: number;
 
-  @ManyToOne(
-    () => LectureSchedule,
-    (lectureSchedule) => lectureSchedule.lectureStatus,
-  )
-  lectureSchedule: LectureSchedule;
-
-  @ManyToOne(() => Lecture, (lecture) => lecture.lectureStatus)
-  lecture: Lecture;
+  @OneToOne(() => LectureOption, (option) => option.lectureStatus)
+  @JoinColumn() // JoinColumn을 사용해 외래키를 설정
+  lectureOption: LectureOption;
 }

--- a/src/lecture/entity/lecture.status.entity.ts
+++ b/src/lecture/entity/lecture.status.entity.ts
@@ -1,0 +1,21 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { LectureSchedule } from './lecture.schedule.entity';
+import { Lecture } from './lecture.entity';
+
+@Entity()
+export class LectureStatus {
+  @PrimaryGeneratedColumn({ type: 'int' })
+  id: number;
+
+  @Column({ type: 'int' })
+  available_seats: number;
+
+  @ManyToOne(
+    () => LectureSchedule,
+    (lectureSchedule) => lectureSchedule.lectureStatus,
+  )
+  lectureSchedule: LectureSchedule;
+
+  @ManyToOne(() => Lecture, (lecture) => lecture.lectureStatus)
+  lecture: Lecture;
+}

--- a/src/lecture/interfaces/lecture.repository.Impl.ts
+++ b/src/lecture/interfaces/lecture.repository.Impl.ts
@@ -1,0 +1,28 @@
+import { LectureRepository } from '../lecture.repository';
+import { Injectable } from '@nestjs/common';
+import { MoreThan, Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LectureSchedule } from '../entity/lecture.schedule.entity';
+
+@Injectable()
+export class LectureRepositoryImpl implements LectureRepository {
+  constructor(
+    @InjectRepository(LectureSchedule)
+    private lectureScheduleRepository: Repository<LectureSchedule>,
+  ) {}
+
+  // 주어진 날짜로 신청 가능한 특강 목록을 TypeORM 메서드를 이용해 조회
+  async findAvailableLecturesByDate(
+    lectureDate: Date,
+  ): Promise<LectureSchedule[]> {
+    return await this.lectureScheduleRepository.find({
+      where: {
+        lectureDate: MoreThan(lectureDate),
+        lectureStatus: {
+          available_seats: MoreThan(0), // 좌석이 0보다 많을 때만
+        },
+      },
+      relations: ['lecture', 'lectureStatus'], // 관계된 엔티티도 함께 로드
+    });
+  }
+}

--- a/src/lecture/interfaces/lecture.repository.Impl.ts
+++ b/src/lecture/interfaces/lecture.repository.Impl.ts
@@ -2,20 +2,20 @@ import { LectureRepository } from '../lecture.repository';
 import { Injectable } from '@nestjs/common';
 import { MoreThan, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
-import { LectureSchedule } from '../entity/lecture.schedule.entity';
+import { LectureOption } from '../entity/lecture.option.entity';
 
 @Injectable()
 export class LectureRepositoryImpl implements LectureRepository {
   constructor(
-    @InjectRepository(LectureSchedule)
-    private lectureScheduleRepository: Repository<LectureSchedule>,
+    @InjectRepository(LectureOption)
+    private lectureOptionRepository: Repository<LectureOption>,
   ) {}
 
   // 주어진 날짜로 신청 가능한 특강 목록을 TypeORM 메서드를 이용해 조회
   async findAvailableLecturesByDate(
     lectureDate: Date,
-  ): Promise<LectureSchedule[]> {
-    return await this.lectureScheduleRepository.find({
+  ): Promise<LectureOption[]> {
+    return await this.lectureOptionRepository.find({
       where: {
         lectureDate: MoreThan(lectureDate),
         lectureStatus: {

--- a/src/lecture/lecture.controller.ts
+++ b/src/lecture/lecture.controller.ts
@@ -1,16 +1,13 @@
 import { ParseDatePipe } from 'src/common/pipe/parse.date.pipe';
 import { LectureService } from './lecture.service';
 import { Controller, Get, Param } from '@nestjs/common';
-import { LectureListDto } from './dto/lecutre.list.dto';
 
 @Controller('lecture')
 export class LectureController {
   constructor(private readonly lectureService: LectureService) {}
 
   @Get('/:date')
-  async lecture(
-    @Param('date', ParseDatePipe) date: Date,
-  ): Promise<LectureListDto[]> {
+  async lecture(@Param('date', ParseDatePipe) date: Date) {
     return await this.lectureService.getListByDate(date);
   }
 }

--- a/src/lecture/lecture.controller.ts
+++ b/src/lecture/lecture.controller.ts
@@ -1,0 +1,16 @@
+import { ParseDatePipe } from 'src/common/pipe/parse.date.pipe';
+import { LectureService } from './lecture.service';
+import { Controller, Get, Param } from '@nestjs/common';
+import { LectureListDto } from './dto/lecutre.list.dto';
+
+@Controller('lecture')
+export class LectureController {
+  constructor(private readonly lectureService: LectureService) {}
+
+  @Get('/:date')
+  async lecture(
+    @Param('date', ParseDatePipe) date: Date,
+  ): Promise<LectureListDto[]> {
+    return await this.lectureService.getListByDate(date);
+  }
+}

--- a/src/lecture/lecture.mapper.ts
+++ b/src/lecture/lecture.mapper.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { LectureOption } from './entity/lecture.option.entity';
+import { LectureListDto } from './dto/lecutre.list.dto';
+import { plainToInstance } from 'class-transformer';
+
+@Injectable()
+export class LectureMapper {
+  toLectureListDto(lectures: LectureOption[]): LectureListDto[] {
+    return plainToInstance(
+      LectureListDto,
+      lectures
+        .filter(
+          (lectureOption) => lectureOption.lectureStatus.available_seats > 0,
+        )
+        .map((lectureOption) => ({
+          id: lectureOption.id,
+          lectureDate: lectureOption.lectureDate,
+          available_seats: lectureOption.lectureStatus.available_seats,
+          capacity: lectureOption.capacity,
+          title: lectureOption.lecture.title,
+          coach: lectureOption.lecture.coach,
+        })),
+    );
+  }
+}

--- a/src/lecture/lecture.module.ts
+++ b/src/lecture/lecture.module.ts
@@ -1,0 +1,24 @@
+import { Lecture } from '../lecture/entity/lecture.entity';
+import { Module } from '@nestjs/common';
+import { LectureController } from './lecture.controller';
+import { LectureService } from './lecture.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LectureRepositoryImpl } from './interfaces/lecture.repository.Impl';
+import { LECTURE_REPOSITORY } from './lecture.repository';
+import { LectureSchedule } from './entity/lecture.schedule.entity';
+import { LectureStatus } from './entity/lecture.status.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Lecture, LectureStatus, LectureSchedule]),
+  ],
+  controllers: [LectureController],
+  providers: [
+    {
+      provide: LECTURE_REPOSITORY,
+      useClass: LectureRepositoryImpl,
+    },
+    LectureService,
+  ],
+})
+export class LectureModule {}

--- a/src/lecture/lecture.module.ts
+++ b/src/lecture/lecture.module.ts
@@ -1,17 +1,15 @@
-import { Lecture } from '../lecture/entity/lecture.entity';
 import { Module } from '@nestjs/common';
 import { LectureController } from './lecture.controller';
 import { LectureService } from './lecture.service';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { LectureRepositoryImpl } from './interfaces/lecture.repository.Impl';
 import { LECTURE_REPOSITORY } from './lecture.repository';
-import { LectureSchedule } from './entity/lecture.schedule.entity';
+import { Lecture } from './entity/lecture.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { LectureStatus } from './entity/lecture.status.entity';
+import { LectureOption } from './entity/lecture.option.entity';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Lecture, LectureStatus, LectureSchedule]),
-  ],
+  imports: [TypeOrmModule.forFeature([Lecture, LectureStatus, LectureOption])],
   controllers: [LectureController],
   providers: [
     {

--- a/src/lecture/lecture.repository.ts
+++ b/src/lecture/lecture.repository.ts
@@ -1,0 +1,7 @@
+import { LectureSchedule } from './entity/lecture.schedule.entity';
+
+export const LECTURE_REPOSITORY = Symbol('LECTURE_REPOSITORY');
+
+export interface LectureRepository {
+  findAvailableLecturesByDate(date: Date): Promise<LectureSchedule[]>;
+}

--- a/src/lecture/lecture.repository.ts
+++ b/src/lecture/lecture.repository.ts
@@ -1,7 +1,6 @@
-import { LectureSchedule } from './entity/lecture.schedule.entity';
-
 export const LECTURE_REPOSITORY = Symbol('LECTURE_REPOSITORY');
 
 export interface LectureRepository {
-  findAvailableLecturesByDate(date: Date): Promise<LectureSchedule[]>;
+  // findAvailableLecturesByDate(date: Date): Promise<lectureOptionRepository[]>;
+  findAvailableLecturesByDate(date: Date);
 }

--- a/src/lecture/lecture.service.ts
+++ b/src/lecture/lecture.service.ts
@@ -1,0 +1,44 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { LectureRepository, LECTURE_REPOSITORY } from './lecture.repository';
+import { plainToInstance } from 'class-transformer';
+import { LectureListDto } from './dto/lecutre.list.dto';
+import { LectureSchedule } from './entity/lecture.schedule.entity';
+
+@Injectable()
+export class LectureService {
+  private readonly MAX_AUDIENCE_COUNT = 30;
+
+  constructor(
+    @Inject(LECTURE_REPOSITORY)
+    private readonly lectureRepository: LectureRepository,
+  ) {}
+
+  //날짜별로 현재 신청 가능한 특강 목록을 조회하는 API
+  async getListByDate(date: Date): Promise<LectureListDto[]> {
+    const lectures = await this.getLecturesByDate(date);
+    return this.convertToDto(lectures);
+  }
+
+  //날짜별로 최대 관중 수에 맞는 특강을 조회
+  async getLecturesByDate(date: Date): Promise<LectureSchedule[]> {
+    return await this.lectureRepository.findAvailableLecturesByDate(date);
+  }
+
+  // Lecture 엔티티 배열을 LectureListDto 배열로 변환
+  convertToDto(lectures: LectureSchedule[]): LectureListDto[] {
+    return lectures.map((lecture: LectureSchedule) => {
+      const availableSeats = lecture.lectureStatus[0]?.available_seats ?? 0;
+
+      return plainToInstance(LectureListDto, {
+        id: lecture.id,
+        lectureDate: lecture.lectureDate,
+        availableSeats,
+        lecture: {
+          id: lecture.id,
+          title: lecture.lecture.title,
+          lecturer: lecture.lecture.lecturer,
+        },
+      });
+    });
+  }
+}

--- a/src/lecture/lecture.service.ts
+++ b/src/lecture/lecture.service.ts
@@ -1,44 +1,25 @@
+import { LectureMapper } from './lecture.mapper';
 import { Inject, Injectable } from '@nestjs/common';
-import { LectureRepository, LECTURE_REPOSITORY } from './lecture.repository';
-import { plainToInstance } from 'class-transformer';
 import { LectureListDto } from './dto/lecutre.list.dto';
-import { LectureSchedule } from './entity/lecture.schedule.entity';
+import { LectureOption } from './entity/lecture.option.entity';
+import { LectureRepository, LECTURE_REPOSITORY } from './lecture.repository';
 
 @Injectable()
 export class LectureService {
-  private readonly MAX_AUDIENCE_COUNT = 30;
-
   constructor(
     @Inject(LECTURE_REPOSITORY)
     private readonly lectureRepository: LectureRepository,
+    private readonly lectureMapper: LectureMapper,
   ) {}
 
   //날짜별로 현재 신청 가능한 특강 목록을 조회하는 API
   async getListByDate(date: Date): Promise<LectureListDto[]> {
     const lectures = await this.getLecturesByDate(date);
-    return this.convertToDto(lectures);
+    return this.lectureMapper.toLectureListDto(lectures);
   }
 
   //날짜별로 최대 관중 수에 맞는 특강을 조회
-  async getLecturesByDate(date: Date): Promise<LectureSchedule[]> {
+  async getLecturesByDate(date: Date): Promise<LectureOption[]> {
     return await this.lectureRepository.findAvailableLecturesByDate(date);
-  }
-
-  // Lecture 엔티티 배열을 LectureListDto 배열로 변환
-  convertToDto(lectures: LectureSchedule[]): LectureListDto[] {
-    return lectures.map((lecture: LectureSchedule) => {
-      const availableSeats = lecture.lectureStatus[0]?.available_seats ?? 0;
-
-      return plainToInstance(LectureListDto, {
-        id: lecture.id,
-        lectureDate: lecture.lectureDate,
-        availableSeats,
-        lecture: {
-          id: lecture.id,
-          title: lecture.lecture.title,
-          lecturer: lecture.lecture.lecturer,
-        },
-      });
-    });
   }
 }

--- a/src/lecture/test/lecture.controller.spec.ts
+++ b/src/lecture/test/lecture.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LectureController } from '../lecture.controller';
+
+describe('LectureController', () => {
+  let controller: LectureController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LectureController],
+    }).compile();
+
+    controller = module.get<LectureController>(LectureController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/lecture/test/lecture.service.spec.ts
+++ b/src/lecture/test/lecture.service.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LectureService } from '../lecture.service';
+import { LECTURE_REPOSITORY, LectureRepository } from '../lecture.repository';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+
+describe('LectureService', () => {
+  let lectureService: LectureService;
+  let lectureRepository: DeepMocked<LectureRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LectureService,
+        {
+          provide: LECTURE_REPOSITORY,
+          useValue: createMock<LectureRepository>(),
+        },
+      ],
+    }).compile();
+
+    lectureService = module.get<LectureService>(LectureService);
+    lectureRepository = module.get(LECTURE_REPOSITORY); // 인터페이스를 주입
+  });
+
+  it('should be defined', () => {
+    expect(lectureService).toBeDefined();
+  });
+});


### PR DESCRIPTION
### 작업내역
- **특강 목록 조회**
    - `LectureSchedule Entity`의 `lectureDate`를 통해 수업을 조회합니다. 
    - 정원이 30명 미만이거나, Param 날짜 이후 일 때만 조회가 가능합니다. 
    - api: `/lecture/:date`

- **ParseDate Pipe**
    - 매개변수로 들어온 날짜의 유효성을 확인하는 파이프입니다.

### 의사결정 흐름 
- 향후 데이터베이스 변경을 유연하게 처리하기 위해, 레포지토리 레이어를 추상체와 구현체로 분리하였습니다.
    - 구현체와 추상체 간의 의존성을 동적으로 관리하기 위해 **NestJS의 useClass**를 활용하여 종속성을 주입하였습니다. 이를 통해 추상체 요청 시, 커스텀 로직에 따라 레포지토리 구현체와 `TypeOrm`과 같은 구현체가 주입되도록 설정하였습니다.


  
  
### Entity 설계 

![mermaid-diagram-2024-10-02-195431](https://github.com/user-attachments/assets/85e27ca0-0f31-4a09-a0d2-4cbb630e1073)

1. Lecture (특강):
     - 특강에 대한 기본 정보를 저장하는 테이블로, 특강 제목과 코치를 저장합니다. 다른 엔티티들이 이 테이블과 관계를 맺어 강의의 스케줄과 상태를 관리할 수 있도록 합니다.

2. LectureSchedule (특강 스케줄):
    - 특강이 열리는 날짜와 정원을 관리하는 테이블입니다. 특강이란 특별히 진행하는 강의를 뜻합니다. 특강은 여러 번 열릴 수도 있고, 각 특강 별로 정원 수도 바뀔 수 있기 때문에  Lecture와 1 관계를 맺어 각 강의의 스케줄을 효율적으로 관리합니다.


3. LectureStatus (강의 상태):
    - 강의의 현재 상태, 즉 남은 좌석 수를 관리하는 테이블입니다. 강의와 스케줄 각각과 N:1 관계를 맺어 특정 날짜에 열리는 강의의 남은 좌석을 추적합니다.

4. Reservation (예약):
    - 사용자가 특정 강의에 대한 예약 정보를 저장하는 테이블입니다. 사용자가 하나의 강의에 대해서만 예약할 수 있도록 제약을 두고, 사용자의 예약 내역을 추적할 수 있습니다.



### 리뷰 포인트🫨
- 레포지토리 레이어에서 추상체와 구현체의 분리가 적절하게 이루어졌는지에 대한 의견
- 예약 기능 및 관련 Entity는 추후 개발 예정입니다. 현재 설계와 흐름이 적절한지 검토 부탁드립니다.
